### PR TITLE
Delete QuadVertexBufferBase on shutdown

### DIFF
--- a/Remc/src/Remc/Renderer/Renderer2D.cpp
+++ b/Remc/src/Remc/Renderer/Renderer2D.cpp
@@ -108,6 +108,8 @@ namespace Remc {
 	void Renderer2D::Shutdown()
 	{
 		REMC_PROFILE_FUNCTION();
+
+		delete[] s_Data.QuadVertexBufferBase;
 	}
 
 	void Renderer2D::BeginScene(const OrthographicCamera& camera)


### PR DESCRIPTION
#### Describe the issue (if no issue has been made)
s_Data.QuadVertexBufferBase is allocated in Init, but isn't deleted on Shutdown.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix

Delete s_Data.QuadVertexBufferBase in the Shutdown method.