### PR TITLE
Imgui Swallowing

### DIFF
--- a/Remc/src/Remc/Core/Application.cpp
+++ b/Remc/src/Remc/Core/Application.cpp
@@ -62,9 +62,9 @@ namespace Remc {
 
 		for (auto it = m_LayerStack.rbegin(); it != m_LayerStack.rend(); ++it)
 		{
-			(*it)->OnEvent(e);
 			if (e.Handled)
 				break;
+			(*it)->OnEvent(e);
 		}
 	}
 

--- a/Remc/src/Remc/ImGui/ImGuiLayer.cpp
+++ b/Remc/src/Remc/ImGui/ImGuiLayer.cpp
@@ -60,6 +60,13 @@ namespace Remc {
 		ImGui::DestroyContext();
 	}
 	
+	void ImGuiLayer::OnEvent(Event& e)
+	{
+		ImGuiIO& io = ImGui::GetIO();
+		e.Handled |= e.IsInCategory(EventCategoryMouse) & io.WantCaptureMouse;
+		e.Handled |= e.IsInCategory(EventCategoryKeyboard) & io.WantCaptureKeyboard;
+	}
+
 	void ImGuiLayer::Begin()
 	{
 		REMC_PROFILE_FUNCTION();

--- a/Remc/src/Remc/ImGui/ImGuiLayer.h
+++ b/Remc/src/Remc/ImGui/ImGuiLayer.h
@@ -16,6 +16,7 @@ namespace Remc {
 
 		virtual void OnAttach() override;
 		virtual void OnDetach() override;
+		virtual void OnEvent(Event& e) override;
 		// virtual void OnImGuiRender() override;
 
 		void Begin();


### PR DESCRIPTION
#### Describe the issue
ImGui sometimes wants mouse and/or key inputs, when it does,
stop events from reaching the rest of the layers.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Provide an OnEvent function for ImGui, so it can set events to handled when it wants input.