### PR TITLE
Fix incorrect macro names and wrong syntax.

### DIFF
--- a/Remc/src/Remc/DeBug/Instrumentor.h
+++ b/Remc/src/Remc/DeBug/Instrumentor.h
@@ -207,7 +207,7 @@ namespace Remc {
 
 	#define REMC_PROFILE_BEGIN_SESSION(name, filepath) ::Remc::Instrumentor::Get().BeginSession(name, filepath)
 	#define REMC_PROFILE_END_SESSION() ::Remc::Instrumentor::Get().EndSession()
-	#define HZ_PROFILE_SCOPE(name) constexpr auto fixedName = ::Remc::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
+	#define REMC_PROFILE_SCOPE(name) constexpr auto fixedName = ::Remc::InstrumentorUtils::CleanupOutputString(name, "__cdecl ");\
 						::Remc::InstrumentationTimer timer##__LINE__(fixedName.Data)
 	#define REMC_PROFILE_FUNCTION() REMC_PROFILE_SCOPE(REMC_FUNC_SIG)
 #else

--- a/premake5.lua
+++ b/premake5.lua
@@ -56,7 +56,7 @@ project "Remc"
 
 	defines
 	{
-		"_CRT_SECURE_NO_WARNINGS"
+		"_CRT_SECURE_NO_WARNINGS",
 		"GLFW_INCLUDE_NONE"
 	}
 


### PR DESCRIPTION
#### Describe the issue
- Incorrect macro name in Instrumentor.h
- Incorrect syntax in premake5.lua

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None