### PR TITLE
Fixed copy and paste mistake on EntryPoint.h

### DIFF
--- a/Remc/src/Remc/Core/EntryPoint.h
+++ b/Remc/src/Remc/Core/EntryPoint.h
@@ -19,7 +19,7 @@ int main(int argc, char** argv)
 	app->Run();
 	REMC_PROFILE_END_SESSION();
 
-	REMC_PROFILE_BEGIN_SESSION("Startup", "RemcProfile-Shutdown.json");
+	REMC_PROFILE_BEGIN_SESSION("Shutdown", "RemcProfile-Shutdown.json");
 	delete app;
 	REMC_PROFILE_END_SESSION();
 }


### PR DESCRIPTION
#### Describe the issue
The profiler should treat deleting the app as a different session.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None