### PR TITLE
Fix black flicker on resize

### DIFF
--- a/RTShell/src/EditorLayer.cpp
+++ b/RTShell/src/EditorLayer.cpp
@@ -32,6 +32,15 @@ namespace Remc {
 	{
 		REMC_PROFILE_FUNCTION();
 
+		// Resize
+		if (Remc::FramebufferSpecification spec = m_Framebuffer->GetSpecification();
+			m_ViewportSize.x > 0.0f && m_ViewportSize.y > 0.0f && // zero sized framebuffer is invalid
+			(spec.Width != m_ViewportSize.x || spec.Height != m_ViewportSize.y))
+		{
+			m_Framebuffer->Resize((uint32_t)m_ViewportSize.x, (uint32_t)m_ViewportSize.y);
+			m_CameraController.OnResize(m_ViewportSize.x, m_ViewportSize.y);
+		}
+
 		// Update
 		if (m_ViewportFocused)
 		{
@@ -170,13 +179,7 @@ namespace Remc {
 			Application::Get().GetImGuiLayer()->BlockEvents(!m_ViewportFocused || !m_ViewportHovered);
 
 			ImVec2 viewportPanelSize = ImGui::GetContentRegionAvail();
-			if (m_ViewportSize != *((glm::vec2*)&viewportPanelSize))
-			{
-				m_Framebuffer->Resize((uint32_t)viewportPanelSize.x, (uint32_t)viewportPanelSize.y);
-				m_ViewportSize = { viewportPanelSize.x, viewportPanelSize.y };
-
-				m_CameraController.OnResize(viewportPanelSize.x, viewportPanelSize.y);
-			}
+			m_ViewportSize = { viewportPanelSize.x, viewportPanelSize.y };
 			uint32_t textureID = m_Framebuffer->GetColorAttachmentRendererID();
 			ImGui::Image((void*)textureID, ImVec2{ m_ViewportSize.x, m_ViewportSize.y }, ImVec2{ 0, 1 }, ImVec2{ 1, 0 });
 			ImGui::End();


### PR DESCRIPTION
#### Describe the issue
Previously resize happened in the `OnImGuiRender` functionthis runs after `OnUpdate` where the framebuffer gets filled.  
This resulted in ImGui rendering an unfilled/new texture on every resize.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | #7 
Other PRs this solves    | None

#### Proposed fix
This changes the code to do the resize as the first step in `OnUpdate` before we will render to the framebuffer, so we always have a filled framebuffer to render in `OnImGuiRender`.