### PR TITLE
Add EventCategoryMouseButton to MouseButtonEvent

### DIFF
--- a/Remc/src/Remc/Events/MouseEvent.h
+++ b/Remc/src/Remc/Events/MouseEvent.h
@@ -54,7 +54,7 @@ namespace Remc {
 	public:
 		MouseCode GetMouseButton() const { return m_Button; }
 
-		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput)
+		EVENT_CLASS_CATEGORY(EventCategoryMouse | EventCategoryInput | EventCategoryMouseButton)
 	protected:
 		MouseButtonEvent(const MouseCode button)
 			: m_Button(button) {}


### PR DESCRIPTION
#### Describe the issue
`EventCategoryMouseButton` is not being used by any Event.
I think `MouseButtonEvent` should be an `EventCategoryMouseButton`. We can alternatively get rid of it


 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None