### PR TITLE
Removed warnings from External Dependencies

### DIFF
--- a/Remc/src/Remc/Core/Log.h
+++ b/Remc/src/Remc/Core/Log.h
@@ -2,8 +2,11 @@
 
 #include "Remc/Core/Base.h"
 
+// This ignores all warnings raised inside External headers
+#pragma warning(push, 0)
 #include <spdlog/spdlog.h>
 #include <spdlog/fmt/ostr.h>
+#pragma warning(pop)
 
 namespace Remc {
 


### PR DESCRIPTION
#### Describe the issue
There are lot of compiler warnings from External Headers (spdlog and fmt)

#### PR impact
Suppress all warnings from external headers using precompiled commands.
This solution to suppress warning can be found on stackoverflow.
[https://stackoverflow.com/a/2541990/9271231](https://stackoverflow.com/a/2541990/9271231)

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None