### PR TITLE
Removed redundant GetProjection()

### DIFF
--- a/Remc/src/Remc/Scene/Scene.cpp
+++ b/Remc/src/Remc/Scene/Scene.cpp
@@ -67,7 +67,7 @@ namespace Remc {
 
 		if (mainCamera)
 		{
-			Renderer2D::BeginScene(mainCamera->GetProjection(), *cameraTransform);
+			Renderer2D::BeginScene(*mainCamera, *cameraTransform);
 
 			auto group = m_Registry.group<TransformComponent>(entt::get<SpriteRendererComponent>);
 			for (auto entity : group)


### PR DESCRIPTION
### Describe the issue
In `Scene.cpp`, while beginning the scene, the camera'a projection is sent, even though the function requires a `Camera` instance. This creates an unnecessary construction and copy.

#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Giving the `*mainCamera` instead of `mainCamera->GetProjection()` in the `Renderer2D::BeginScene()` function.