### PR TITLE
Fixed two includes to fit the convention and one typo

### DIFF
--- a/Remc/src/Platform/OpenGL/OpenGLFramebuffer.cpp
+++ b/Remc/src/Platform/OpenGL/OpenGLFramebuffer.cpp
@@ -1,5 +1,5 @@
 #include "rcpch.h"
-#include "OpenGLFramebuffer.h"
+#include "Platform/OpenGL/OpenGLFramebuffer.h"
 
 #include <glad/glad.h>
 

--- a/Remc/src/Platform/OpenGL/OpenGLTexture.cpp
+++ b/Remc/src/Platform/OpenGL/OpenGLTexture.cpp
@@ -32,7 +32,7 @@ namespace Remc {
 		stbi_set_flip_vertically_on_load(1);
 		stbi_uc* data = nullptr;
 		{
-			REMC_PROFILE_SCOPE("stbi_load - OpenGLTexture2D::OpenGLTexture2D(const std:string&)");
+			REMC_PROFILE_SCOPE("stbi_load - OpenGLTexture2D::OpenGLTexture2D(const std::string&)");
 			data = stbi_load(path.c_str(), &width, &height, &channels, 0);
 		}
 		REMC_CORE_ASSERT(data, "Failed to load image!");

--- a/Remc/src/Remc/Renderer/Framebuffer.cpp
+++ b/Remc/src/Remc/Renderer/Framebuffer.cpp
@@ -1,5 +1,5 @@
 #include "rcpch.h"
-#include "Framebuffer.h"
+#include "Remc/Renderer/Framebuffer.h"
 
 #include "Remc/Renderer/Renderer.h"
 


### PR DESCRIPTION
#### Describe the issue
Includes in Framebuffer.cpp and OpenGLFramebuffer.cpp did not match the convention to include the whole path.
Fixed one typo in OpenGLTexture for the profile scope.
#### PR impact
List of related issues/PRs this will solve:

 Impact                  | Issue/PR
------------------------ | ------
Issues this solves       | None
Other PRs this solves    | None

#### Proposed fix
Changed the includes and the typo.